### PR TITLE
Refactor z2ui5_cl_sel_var_db: Remove unused methods and simplify

### DIFF
--- a/src/01/z2ui5_cl_sel_var_db.clas.abap
+++ b/src/01/z2ui5_cl_sel_var_db.clas.abap
@@ -3,33 +3,8 @@ CLASS z2ui5_cl_sel_var_db DEFINITION
   CREATE PUBLIC.
 
   PUBLIC SECTION.
-    CLASS-METHODS factory
-      IMPORTING
-        report        TYPE string
-      RETURNING
-        VALUE(result) TYPE REF TO z2ui5_cl_sel_var_db.
-
     TYPES ty_s_db TYPE z2ui5_t_13.
-*    TYPES ty_s_pos TYPE z2ui5_t_14.
-
-    DATA mt_variant TYPE STANDARD TABLE OF ty_s_db WITH EMPTY KEY.
-
-    METHODS check_default.
-    METHODS get_default.
-
     TYPES ty_t_db TYPE STANDARD TABLE OF z2ui5_t_13 WITH EMPTY KEY.
-
-    METHODS db_variant_read
-      IMPORTING
-        name          TYPE string
-      RETURNING
-        VALUE(result) TYPE z2ui5_cl_util=>ty_t_filter_multi.
-
-    METHODS db_variant_save
-      IMPORTING
-        name          TYPE string
-      RETURNING
-        VALUE(result) TYPE z2ui5_cl_util=>ty_t_filter_multi.
 
     CLASS-METHODS db_read_default
       IMPORTING
@@ -49,34 +24,11 @@ CLASS z2ui5_cl_sel_var_db DEFINITION
         data   TYPE data.
 
   PROTECTED SECTION.
-    DATA:
-      BEGIN OF mS_config,
-        classname TYPE string,
-        name      TYPE string,
-        user      TYPE string,
-        timestamp TYPE timestamp,
-        data      TYPE string,
-      END OF mS_config.
-
-    DATA object    TYPE REF TO object.
-    DATA mt_filter TYPE z2ui5_cl_util=>ty_t_filter_multi.
-
-    METHODS obj_to_filter.
-    METHODS filter_to_object.
-
   PRIVATE SECTION.
 ENDCLASS.
 
 
 CLASS z2ui5_cl_sel_var_db IMPLEMENTATION.
-
-  METHOD obj_to_filter.
-
-  ENDMETHOD.
-
-  METHOD filter_to_object.
-
-  ENDMETHOD.
 
   METHOD db_read.
 
@@ -97,33 +49,6 @@ CLASS z2ui5_cl_sel_var_db IMPLEMENTATION.
 
     MODIFY z2ui5_t_13 FROM @ls_db.
     COMMIT WORK AND WAIT.
-
-  ENDMETHOD.
-
-  METHOD factory.
-
-    result = NEW #( ).
-
-*    SELECT FROM z2ui5_t_13
-*      FIELDS *
-*      WHERE classname = @report
-*      INTO TABLE @result->mt_variant.
-
-  ENDMETHOD.
-
-  METHOD check_default.
-
-  ENDMETHOD.
-
-  METHOD db_variant_read.
-
-  ENDMETHOD.
-
-  METHOD get_default.
-
-  ENDMETHOD.
-
-  METHOD db_variant_save.
 
   ENDMETHOD.
 
@@ -150,12 +75,9 @@ CLASS z2ui5_cl_sel_var_db IMPLEMENTATION.
     SELECT SINGLE FROM z2ui5_t_13
       FIELDS
        *
-      WHERE
-*        uname    = @s_info-uname AND
-         handle01 = @s_info-handle01 AND
-         check_def = @abap_true
+      WHERE handle01 = @s_info-handle01
+        AND check_def = @abap_true
       INTO @result.
-
 
   ENDMETHOD.
 


### PR DESCRIPTION
## Summary
This PR removes unused and incomplete methods from the `z2ui5_cl_sel_var_db` class, simplifying the codebase and reducing technical debt. The refactoring eliminates stub implementations and unfinished functionality while preserving the core database read/write operations.

## Key Changes
- **Removed unused factory method** that instantiated the class without meaningful initialization
- **Removed incomplete variant management methods**: `db_variant_read`, `db_variant_save`, `check_default`, and `get_default` (all were empty stubs)
- **Removed helper methods**: `obj_to_filter` and `filter_to_object` (empty implementations)
- **Removed unused instance data**: `mt_variant`, `mS_config`, `object`, and `mt_filter` attributes that were never utilized
- **Cleaned up SQL formatting** in `db_read_default` method for better readability (reformatted WHERE clause)
- **Removed commented-out code** and unnecessary blank lines

## Implementation Details
The class now focuses on its core responsibility: reading and writing selection variant data to the database. The `db_read`, `db_write`, and `db_read_default` methods remain as the primary public interface. This cleanup reduces the class complexity and makes the actual functionality more apparent.

https://claude.ai/code/session_0127DCoD9XFp43K91kPvmtJc